### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -10,7 +10,7 @@
   <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpclient.version}"/>
   <dependency org="log4j" name="log4j" rev="1.2.16" />
   <dependency org="com.google.inject" name="guice" rev="2.0"/>
-  <dependency org="com.google.guava" name="guava" rev="23.0" />
+  <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
   <dependency org="org.openid4java" name="openid4java" rev="1.0.0"/>
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally